### PR TITLE
Remove user from kwargs in _chain method

### DIFF
--- a/pinax/documents/managers.py
+++ b/pinax/documents/managers.py
@@ -64,5 +64,5 @@ class SharedMemberQuerySet(QuerySet):
             yield obj
 
     def _chain(self, **kwargs):
-        kwargs["user"] = self.user
+        #kwargs["user"] = self.user
         return super()._chain(**kwargs)


### PR DESCRIPTION
- Remove user from kwargs in _chain method (empty in Django 4)